### PR TITLE
Beatpulse HttpLiveness and Functional Tests

### DIFF
--- a/samples/HttpApi-Basic/Startup.cs
+++ b/samples/HttpApi-Basic/Startup.cs
@@ -58,7 +58,7 @@ namespace HttpApi_Basic
             {
                 app.UseDeveloperExceptionPage();
             }
-
+            
             app.UseMvc();
         }
     }

--- a/src/BeatPulse/Core/Http/HttpLiveness.cs
+++ b/src/BeatPulse/Core/Http/HttpLiveness.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace BeatPulse.Core.Http
+{
+    public class HttpLiveness : IBeatPulseLiveness
+    {
+        public string Name => nameof(HttpLiveness);
+
+        public string DefaultPath => "httpcheck";
+
+        private HttpLivenessOptions _httpOptions;
+        private int _defaultTimeout = 5;
+
+        public HttpLiveness(Action<HttpLivenessOptions> options)
+        {
+            options(_httpOptions);              
+        }
+
+        public HttpLiveness(HttpLivenessOptions options)
+        {
+            _httpOptions = options;
+        }
+
+        public async Task<(string, bool)> IsHealthy(HttpContext context, bool isDevelopment, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using (var client = new HttpClient())
+                {                    
+                    client.Timeout = TimeSpan.FromSeconds(_httpOptions.TimeOut ?? _defaultTimeout);
+                    var requestMessage = new HttpRequestMessage(_httpOptions.Method, _httpOptions.Url);                                        
+                    var response = await client.SendAsync(requestMessage);
+                    await AssertResponse(response);
+                    return (BeatPulseKeys.BEATPULSE_HEALTHCHECK_DEFAULT_OK_MESSAGE, true);
+                }
+            }
+            catch (Exception ex)
+            {               
+                return (ex.Message, false);
+            }
+        }
+
+        private async Task AssertResponse(HttpResponseMessage response)
+        {
+            if (_httpOptions.StatusCodeCheck.HasValue && (int)response.StatusCode != _httpOptions.StatusCodeCheck.Value)
+            {
+                CreateException(HttpLivenessErrors.INVALID_STATUS_CODE);
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            if(!string.IsNullOrEmpty(_httpOptions.ContentCheck) && !content.Contains(_httpOptions.ContentCheck))
+            {
+                CreateException(HttpLivenessErrors.INVALID_RESPONSE_CONTENT);
+            }                       
+        }
+
+        private void CreateException(string message)
+        {
+            throw new Exception($"Error checking {_httpOptions.Url}: {message}");
+        }
+    }
+}

--- a/src/BeatPulse/Core/Http/HttpLivenessErrors.cs
+++ b/src/BeatPulse/Core/Http/HttpLivenessErrors.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BeatPulse.Core.Http
+{
+    public class HttpLivenessErrors
+    {
+        public const string INVALID_STATUS_CODE = "The configured status code to check does not match response";
+        public const string INVALID_RESPONSE_CONTENT = "The configured content to check does not match response";
+    }
+}

--- a/src/BeatPulse/Core/Http/HttpLivenessOptions.cs
+++ b/src/BeatPulse/Core/Http/HttpLivenessOptions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace BeatPulse.Core.Http
+{
+    public class HttpLivenessOptions
+    {
+        public string Url { get; private set; }
+        public string ContentCheck { get; private set; }
+        public int? StatusCodeCheck { get; set; }
+        public int? TimeOut { get; private set; }
+        public HttpMethod Method { get; private set; } = HttpMethod.Get;
+        
+        public HttpLivenessOptions WithUrl(string url)
+        {
+            Url = url;
+            return this;
+        }
+        /// <summary>
+        /// Configure request timeout for the current http liveness
+        /// </summary>
+        /// <param name="timeout">Timeout in seconds</param>
+        /// <returns></returns>
+        public HttpLivenessOptions WithTimeout(int timeout)
+        {
+            TimeOut = timeout;
+            return this;
+        }
+
+        public HttpLivenessOptions WithContentCheck(string contentToCheck)
+        {
+            ContentCheck = contentToCheck;
+            return this;
+        }
+
+        public HttpLivenessOptions WithMethod(HttpMethod method)
+        {
+            Method = method;
+            return this;
+        }
+
+        public HttpLivenessOptions WithStatusCode(int statusCode)
+        {
+            StatusCodeCheck = statusCode;
+            return this;
+        }
+        
+    }
+}

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpConfiguredResponseServer.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpConfiguredResponseServer.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 
 namespace FunctionalTests.Beatpulse.Http.Fixtures
 {
-    public class HttpConfiguredTargetServer: IDisposable
+    public class HttpConfiguredResponseServer: IDisposable
     {
         public const string DefaultTargetServerUrl = "http://localhost:54000";
         private readonly RequestDelegate _delegate;
         private IWebHost _server = null;
 
-        public HttpConfiguredTargetServer(RequestDelegate @delegate, string url = DefaultTargetServerUrl)
+        public HttpConfiguredResponseServer(RequestDelegate @delegate, string url = DefaultTargetServerUrl)
         {
             _server = new WebHostBuilder()
                 .UseUrls(new[] { url })

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpConfiguredTargetServer.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpConfiguredTargetServer.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FunctionalTests.Beatpulse.Http.Fixtures
+{
+    public class HttpConfiguredTargetServer: IDisposable
+    {
+        public const string DefaultTargetServerUrl = "http://localhost:54000";
+        private readonly RequestDelegate _delegate;
+        private IWebHost _server = null;
+
+        public HttpConfiguredTargetServer(RequestDelegate @delegate, string url = DefaultTargetServerUrl)
+        {
+            _server = new WebHostBuilder()
+                .UseUrls(new[] { url })
+                .UseKestrel()
+                .Configure(app =>
+                {
+                    app.Run(@delegate);
+                })
+            .Build();
+            //Blocking operation on tests to achieve IDisposable server
+            _server.StartAsync().GetAwaiter().GetResult();
+        }       
+        public void Dispose()
+        {
+            //Blocking operation on tests to achieve IDisposable server
+            _server.StopAsync().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
@@ -2,50 +2,26 @@
 using FunctionalTests.Base;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNetCore.Http;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 
 namespace FunctionalTests.Beatpulse.Http.Fixtures
 {
     public class HttpLivenessGivenFixture
-    {
-        public const string DefaultTargetServerUrl  = "http://localhost:54000";
-
+    {       
         public TestServer AServerWithHttpLiveness(HttpLivenessOptions options)
-        {      
+        {
             var webHostBuilder = new WebHostBuilder()
                 .UseStartup<DefaultStartup>()
                 .UseBeatPulse()
                 .ConfigureServices(services =>
                 {
                     services.AddBeatPulse(context =>
-                    {
+                    {                        
                         context.Add(new HttpLiveness(options));
                     });
                 });
 
             return new TestServer(webHostBuilder);
         }
-
-        public IWebHost ATargetServerWithConfiguredResponse(RequestDelegate @delegate, string url = DefaultTargetServerUrl)
-        {
-            
-            var webhost = new WebHostBuilder()
-                .UseUrls(new[] {url})               
-                .UseKestrel()
-                .Configure( app => {
-                    app.Run(@delegate);
-                })
-                .Build();           
-
-            return webhost;
-        }
-
-      
     }
 }

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
@@ -14,7 +14,7 @@ namespace FunctionalTests.Beatpulse.Http.Fixtures
 {
     public class HttpLivenessGivenFixture
     {
-        public static string TargetServerUrl { get; } = "http://localhost:54000";
+        public const string DefaultTargetServerUrl  = "http://localhost:54000";
 
         public TestServer AServerWithHttpLiveness(HttpLivenessOptions options)
         {      
@@ -32,11 +32,11 @@ namespace FunctionalTests.Beatpulse.Http.Fixtures
             return new TestServer(webHostBuilder);
         }
 
-        public IWebHost ATargetServerWithConfiguredResponse(RequestDelegate @delegate, string url = "http://localhost:54000")
+        public IWebHost ATargetServerWithConfiguredResponse(RequestDelegate @delegate, string url = DefaultTargetServerUrl)
         {
             
             var webhost = new WebHostBuilder()
-                .UseUrls(new[] { url ?? TargetServerUrl })               
+                .UseUrls(new[] {url})               
                 .UseKestrel()
                 .Configure( app => {
                     app.Run(@delegate);

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
@@ -1,0 +1,53 @@
+﻿using BeatPulse.Core.Http;
+using FunctionalTests.Base;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+
+namespace FunctionalTests.Beatpulse.Http.Fixtures
+{
+    public class HttpLivenessGivenFixture
+    {
+        public static string TargetServerUrl { get; } = "http://localhost:54000";
+
+        public TestServer AServerWithHttpLiveness(HttpLivenessOptions options)
+        {
+            var urlSegments = options.Url.Split("/");
+
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .UseBeatPulse()
+                .ConfigureServices(services =>
+                {
+                    services.AddBeatPulse(context =>
+                    {
+                        context.Add(new HttpLiveness(options));
+                    });
+                });
+
+            return new TestServer(webHostBuilder);
+        }
+
+        public IWebHost ATargetServerWithConfiguredResponse(RequestDelegate @delegate, string url = "http://localhost:54000")
+        {
+            
+            var webhost = new WebHostBuilder()
+                .UseUrls(new[] { url ?? TargetServerUrl })               
+                .UseKestrel()
+                .Configure( app => {
+                    app.Run(@delegate);
+                })
+                .Build();           
+
+            return webhost;
+        }
+
+      
+    }
+}

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/Fixtures/HttpLivenessGivenFixture.cs
@@ -17,9 +17,7 @@ namespace FunctionalTests.Beatpulse.Http.Fixtures
         public static string TargetServerUrl { get; } = "http://localhost:54000";
 
         public TestServer AServerWithHttpLiveness(HttpLivenessOptions options)
-        {
-            var urlSegments = options.Url.Split("/");
-
+        {      
             var webHostBuilder = new WebHostBuilder()
                 .UseStartup<DefaultStartup>()
                 .UseBeatPulse()

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
@@ -28,10 +28,10 @@ namespace FunctionalTests.Beatpulse.Http
         [Fact]
         public async Task be_healthy_when_success_response_from_endpoint_with_default_options()
         {
-            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}");
+            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpConfiguredResponseServer.DefaultTargetServerUrl}");
             var server = _given.AServerWithHttpLiveness(livenessOptions);
 
-            using (var targetServer = new HttpConfiguredTargetServer(context => Task.CompletedTask))
+            using (var targetServer = new HttpConfiguredResponseServer(context => Task.CompletedTask))
             {
                 var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
@@ -46,12 +46,12 @@ namespace FunctionalTests.Beatpulse.Http
             var content = "not found";
 
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredResponseServer.DefaultTargetServerUrl}")
                 .WithContentCheck(content)
                 .WithStatusCode(statusCode);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            using (var targetServer = new HttpConfiguredTargetServer(async context =>
+            using (var targetServer = new HttpConfiguredResponseServer(async context =>
             {
                 context.Response.StatusCode = statusCode;
                 await context.Response.WriteAsync(content);
@@ -66,11 +66,11 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_content_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredResponseServer.DefaultTargetServerUrl}")
                 .WithContentCheck("<div>Hello there!</div>");
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            using (var targetServer = new HttpConfiguredTargetServer(
+            using (var targetServer = new HttpConfiguredResponseServer(
                 async context => await context.Response.WriteAsync("Response")))
             {
                 var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
@@ -83,11 +83,11 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_status_code_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredResponseServer.DefaultTargetServerUrl}")
                 .WithStatusCode(404);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            using(var targetServer = new HttpConfiguredTargetServer(context => Task.CompletedTask))
+            using(var targetServer = new HttpConfiguredResponseServer(context => Task.CompletedTask))
             {
                 var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
@@ -99,11 +99,11 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_timeout_excedded()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredResponseServer.DefaultTargetServerUrl}")
                 .WithTimeout(2);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            using(var targetServer = new HttpConfiguredTargetServer(async context => await Task.Delay(3000)))
+            using(var targetServer = new HttpConfiguredResponseServer(async context => await Task.Delay(3000)))
             {
                 var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
@@ -18,7 +18,7 @@ namespace FunctionalTests.Beatpulse.Http
     {
         private readonly ExecutionFixture _fixture;
         private readonly HttpLivenessGivenFixture _given = new HttpLivenessGivenFixture();
-        
+
 
         public http_liveness_should(ExecutionFixture fixture)
         {
@@ -28,99 +28,87 @@ namespace FunctionalTests.Beatpulse.Http
         [Fact]
         public async Task be_healthy_when_success_response_from_endpoint_with_default_options()
         {
-            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}");
-
+            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}");
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse(context => Task.CompletedTask);
-            await targetServer.StartAsync();
-            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
-            response.EnsureSuccessStatusCode();
+            using (var targetServer = new HttpConfiguredTargetServer(context => Task.CompletedTask))
+            {
+                var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
-            await targetServer.StopAsync();
+                response.EnsureSuccessStatusCode();
+            };
         }
 
         [Fact]
         public async Task be_healthy_when_matches_configured_content_and_status_code()
         {
-            var statusCode = 301;
-            var content = "redirect";
+            var statusCode = 404;
+            var content = "not found";
 
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
                 .WithContentCheck(content)
                 .WithStatusCode(statusCode);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse
-                (async context => {
-                    context.Response.StatusCode = statusCode;
-                    await context.Response.WriteAsync(content);
-                });
-
-            await targetServer.StartAsync();
-            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
-
-            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-
-            await targetServer.StopAsync();
+            using (var targetServer = new HttpConfiguredTargetServer(async context =>
+            {
+                context.Response.StatusCode = statusCode;
+                await context.Response.WriteAsync(content);
+            }))
+            {
+                var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+                response.EnsureSuccessStatusCode();
+            };
         }
-
-
 
         [Fact]
         public async Task be_unhealthy_when_configured_content_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
                 .WithContentCheck("<div>Hello there!</div>");
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse
-                (async context => await context.Response.WriteAsync("Response"));
+            using (var targetServer = new HttpConfiguredTargetServer(
+                async context => await context.Response.WriteAsync("Response")))
+            {
+                var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
-            await targetServer.StartAsync();
-            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
-      
-            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-
-            await targetServer.StopAsync();
-        }      
+                response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            }
+        }
 
         [Fact]
         public async Task be_unhealthy_when_configured_status_code_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
                 .WithStatusCode(404);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse( context => Task.CompletedTask);
-            await targetServer.StartAsync();
+            using(var targetServer = new HttpConfiguredTargetServer(context => Task.CompletedTask))
+            {
+                var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
-            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
-            
-            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-
-            await targetServer.StopAsync();
+                response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            }            
         }
 
         [Fact]
         public async Task be_unhealthy_when_configured_timeout_excedded()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
+                .WithUrl($"{HttpConfiguredTargetServer.DefaultTargetServerUrl}")
                 .WithTimeout(2);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse
-                (async context => await Task.Delay(3000));
-            await targetServer.StartAsync();
+            using(var targetServer = new HttpConfiguredTargetServer(async context => await Task.Delay(3000)))
+            {
+                var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
-            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
-
-            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
-            await targetServer.StopAsync();
+                response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            }           
         }
     }
 }

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
@@ -28,15 +28,15 @@ namespace FunctionalTests.Beatpulse.Http
         [Fact]
         public async Task be_healthy_when_success_response_from_endpoint_with_default_options()
         {
-            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}");
+            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}");
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
             var targetServer = _given.ATargetServerWithConfiguredResponse(context => Task.CompletedTask);
             await targetServer.StartAsync();
-
             var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
             response.EnsureSuccessStatusCode();
+
             await targetServer.StopAsync();
         }
 
@@ -47,7 +47,7 @@ namespace FunctionalTests.Beatpulse.Http
             var content = "redirect";
 
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
                 .WithContentCheck(content)
                 .WithStatusCode(statusCode);
 
@@ -59,10 +59,10 @@ namespace FunctionalTests.Beatpulse.Http
                 });
 
             await targetServer.StartAsync();
-
             var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
 
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
             await targetServer.StopAsync();
         }
 
@@ -72,17 +72,18 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_content_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
                 .WithContentCheck("<div>Hello there!</div>");
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse(async context => await context.Response.WriteAsync("Response"));
+            var targetServer = _given.ATargetServerWithConfiguredResponse
+                (async context => await context.Response.WriteAsync("Response"));
 
             await targetServer.StartAsync();
-
             var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
       
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
             await targetServer.StopAsync();
         }      
 
@@ -90,17 +91,17 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_status_code_does_not_match()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
                 .WithStatusCode(404);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
             var targetServer = _given.ATargetServerWithConfiguredResponse( context => Task.CompletedTask);
-
             await targetServer.StartAsync();
 
             var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
-
+            
             response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
             await targetServer.StopAsync();
         }
 
@@ -108,12 +109,12 @@ namespace FunctionalTests.Beatpulse.Http
         public async Task be_unhealthy_when_configured_timeout_excedded()
         {
             var livenessOptions = new HttpLivenessOptions()
-                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithUrl($"{HttpLivenessGivenFixture.DefaultTargetServerUrl}")
                 .WithTimeout(2);
 
             var server = _given.AServerWithHttpLiveness(livenessOptions);
-            var targetServer = _given.ATargetServerWithConfiguredResponse(async context => await Task.Delay(3000));
-
+            var targetServer = _given.ATargetServerWithConfiguredResponse
+                (async context => await Task.Delay(3000));
             await targetServer.StartAsync();
 
             var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();

--- a/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
+++ b/tests/FunctionalTests/Beatpulse.HttpLiveness/HttpLivenessTests.cs
@@ -1,0 +1,125 @@
+﻿using BeatPulse.Core.Http;
+using FunctionalTests.Base;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using BeatPulse;
+using FunctionalTests.Beatpulse.Http.Fixtures;
+using Microsoft.AspNetCore.Http;
+using FluentAssertions;
+using System.Net;
+
+namespace FunctionalTests.Beatpulse.Http
+{
+    [Collection("execution")]
+    public class http_liveness_should
+    {
+        private readonly ExecutionFixture _fixture;
+        private readonly HttpLivenessGivenFixture _given = new HttpLivenessGivenFixture();
+        
+
+        public http_liveness_should(ExecutionFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task be_healthy_when_success_response_from_endpoint_with_default_options()
+        {
+            var livenessOptions = new HttpLivenessOptions().WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}");
+
+            var server = _given.AServerWithHttpLiveness(livenessOptions);
+            var targetServer = _given.ATargetServerWithConfiguredResponse(context => Task.CompletedTask);
+            await targetServer.StartAsync();
+
+            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+
+            response.EnsureSuccessStatusCode();
+            await targetServer.StopAsync();
+        }
+
+        [Fact]
+        public async Task be_healthy_when_matches_configured_content_and_status_code()
+        {
+            var statusCode = 301;
+            var content = "redirect";
+
+            var livenessOptions = new HttpLivenessOptions()
+                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithContentCheck(content)
+                .WithStatusCode(statusCode);
+
+            var server = _given.AServerWithHttpLiveness(livenessOptions);
+            var targetServer = _given.ATargetServerWithConfiguredResponse
+                (async context => {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(content);
+                });
+
+            await targetServer.StartAsync();
+
+            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            await targetServer.StopAsync();
+        }
+
+
+
+        [Fact]
+        public async Task be_unhealthy_when_configured_content_does_not_match()
+        {
+            var livenessOptions = new HttpLivenessOptions()
+                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithContentCheck("<div>Hello there!</div>");
+
+            var server = _given.AServerWithHttpLiveness(livenessOptions);
+            var targetServer = _given.ATargetServerWithConfiguredResponse(async context => await context.Response.WriteAsync("Response"));
+
+            await targetServer.StartAsync();
+
+            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+      
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            await targetServer.StopAsync();
+        }      
+
+        [Fact]
+        public async Task be_unhealthy_when_configured_status_code_does_not_match()
+        {
+            var livenessOptions = new HttpLivenessOptions()
+                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithStatusCode(404);
+
+            var server = _given.AServerWithHttpLiveness(livenessOptions);
+            var targetServer = _given.ATargetServerWithConfiguredResponse( context => Task.CompletedTask);
+
+            await targetServer.StartAsync();
+
+            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            await targetServer.StopAsync();
+        }
+
+        [Fact]
+        public async Task be_unhealthy_when_configured_timeout_excedded()
+        {
+            var livenessOptions = new HttpLivenessOptions()
+                .WithUrl($"{HttpLivenessGivenFixture.TargetServerUrl}")
+                .WithTimeout(2);
+
+            var server = _given.AServerWithHttpLiveness(livenessOptions);
+            var targetServer = _given.ATargetServerWithConfiguredResponse(async context => await Task.Delay(3000));
+
+            await targetServer.StartAsync();
+
+            var response = await server.CreateRequest(BeatPulseKeys.BEATPULSE_DEFAULT_PATH).GetAsync();
+
+            response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+            await targetServer.StopAsync();
+        }
+    }
+}

--- a/tests/FunctionalTests/FunctionalTests.csproj
+++ b/tests/FunctionalTests/FunctionalTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="$(ASPNetCoreAllPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(ASPNetCoreTestHostVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitPackageVersion)" />


### PR DESCRIPTION
BeatPulse HttpLiveness allows the user to configure parameterized Http checks.

The user can configure checks on response content, status code and timeout. Url and Methods are configurable as well.

Sample:

```csharp
new HttpLiveness(options =>
 {
    options.WithUrl("http://whateverservice")
   .WithContentCheck("<div>Checkout</div>")
   .WithStatusCode(200)
   .WithTimeout(3);
 });

new HttpLiveness(options =>
 {
   options.WithUrl("http://whateverurl")
   .WithContentCheck("redirected")
   .WithStatusCode(301);
});

new HttpLiveness(options =>
 {
   options.WithUrl("http://whateverurl")
   .WithMethod(HttpMethod.Post)
   .WithContentCheck("OK");
 });
```


**NOTE:** TestServer does not work when throwing localhost request from within, so a target remote server is configured on functional tests. IMHO this ensures even more the tests as it is a separate server.

