### PR TITLE
Execute all checks when EnabledDetailedOutput is true (fix #31)

### DIFF
--- a/src/BeatPulse/BeatPulseMiddleware.cs
+++ b/src/BeatPulse/BeatPulseMiddleware.cs
@@ -55,7 +55,7 @@ namespace BeatPulse
 
                         using (var cancellationTokenSource = new CancellationTokenSource())
                         {
-                            var task = pulseService.IsHealthy(beatPulsePath, context, cancellationTokenSource.Token);
+                            var task = pulseService.IsHealthy(beatPulsePath, _options, context, cancellationTokenSource.Token);
 
                             if (await Task.WhenAny(task, Task.Delay(_options.Timeout, cancellationTokenSource.Token)) == task)
                             {

--- a/src/BeatPulse/Core/BeatPulseService.cs
+++ b/src/BeatPulse/Core/BeatPulseService.cs
@@ -23,7 +23,7 @@ namespace BeatPulse.Core
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public async Task<IEnumerable<LivenessResult>> IsHealthy(string path, HttpContext httpContext,CancellationToken cancellationToken)
+        public async Task<IEnumerable<LivenessResult>> IsHealthy(string path, BeatPulseOptions options, HttpContext httpContext, CancellationToken cancellationToken)
         {
             _logger.LogInformation($"BeatPulse is checking health on [BeatPulsePath]/{path}");
 
@@ -35,20 +35,20 @@ namespace BeatPulse.Core
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        _logger.LogWarning($"BeatPulse execution is cancelled");
+                        _logger.LogWarning("BeatPulse execution is cancelled");
 
                         break;
                     }
 
-                    var healthCheckResult = await RunLiveness(liveness, httpContext,cancellationToken);
+                    var healthCheckResult = await RunLiveness(liveness, httpContext, cancellationToken);
 
                     livenessResults.Add(healthCheckResult);
 
-                    if (!healthCheckResult.IsHealthy)
+                    if (!healthCheckResult.IsHealthy && !options.DetailedOutput)
                     {
                         //break when first check is not healthy
 
-                        var warningMessage = cancellationToken.IsCancellationRequested 
+                        var warningMessage = cancellationToken.IsCancellationRequested
                             ? $"Liveness {liveness.Name} was cancelled on timeout"
                             : $"Liveness {liveness.Name} is not healthy";
 
@@ -66,7 +66,7 @@ namespace BeatPulse.Core
 
                 if (liveness != null)
                 {
-                    var livenessResult = await RunLiveness(liveness, httpContext,cancellationToken);
+                    var livenessResult = await RunLiveness(liveness, httpContext, cancellationToken);
 
                     return new[] { livenessResult };
                 }
@@ -75,17 +75,17 @@ namespace BeatPulse.Core
             return Enumerable.Empty<LivenessResult>();
         }
 
-        async Task<LivenessResult> RunLiveness(IBeatPulseLiveness liveness, HttpContext httpContext,CancellationToken cancellationToken)
+        async Task<LivenessResult> RunLiveness(IBeatPulseLiveness liveness, HttpContext httpContext, CancellationToken cancellationToken)
         {
             _logger.LogInformation($"Executing liveness {liveness.Name}.");
 
-            var livenessResult = new LivenessResult(liveness.Name,liveness.DefaultPath);
+            var livenessResult = new LivenessResult(liveness.Name, liveness.DefaultPath);
 
             livenessResult.StartCounter();
 
             try
             {
-                var (message, healthy) = await liveness.IsHealthy(httpContext, _environment.IsDevelopment(),cancellationToken);
+                var (message, healthy) = await liveness.IsHealthy(httpContext, _environment.IsDevelopment(), cancellationToken);
 
                 livenessResult.StopCounter(message, healthy);
 

--- a/src/BeatPulse/Core/IBeatPulseService.cs
+++ b/src/BeatPulse/Core/IBeatPulseService.cs
@@ -7,6 +7,6 @@ namespace BeatPulse.Core
 {
     public interface IBeatPulseService
     {
-        Task<IEnumerable<LivenessResult>> IsHealthy(string path, HttpContext context,CancellationToken cancellationToken);
+        Task<IEnumerable<LivenessResult>> IsHealthy(string path, BeatPulseOptions options, HttpContext context, CancellationToken cancellationToken);
     }
 }

--- a/tests/FunctionalTests/BeatPulse/BeatPulseLivenessTests.cs
+++ b/tests/FunctionalTests/BeatPulse/BeatPulseLivenessTests.cs
@@ -1,0 +1,117 @@
+﻿using FluentAssertions;
+using FunctionalTests.Base;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BeatPulse.Core;
+using Xunit;
+
+namespace BeatPulse
+{
+    [Collection("execution")]
+    public class liveness_should
+    {
+        private readonly ExecutionFixture _fixture;
+
+        public liveness_should(ExecutionFixture fixture)
+        {
+            _fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+        }
+
+        [Fact]
+        public async Task return_all_checks_results_when_EnableDetailedOutput_is_true()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .UseBeatPulse(options => options.EnableDetailedOutput())
+                .ConfigureServices(services =>
+                {
+                    services.AddBeatPulse(context =>
+                    {
+                        var httpClient = new HttpClient();
+
+                        context.Add(new ActionLiveness("nok", "nok", async (httpContext, token) =>
+                        {
+                            var responseMessage = await httpClient.GetAsync("http://notexist/api", token);
+
+                            return responseMessage.IsSuccessStatusCode 
+                                ? ("OK", true) 
+                                : ("the not exist api is broken!", false);
+                        }));
+
+                        context.Add(new ActionLiveness("ok", "ok", async (httpContext, token) =>
+                        {
+                            var responseMessage = await httpClient.GetAsync("http://www.google.es", token);
+
+                            return responseMessage.IsSuccessStatusCode
+                                ? ("OK", true)
+                                : ("the not exist api is broken!", false);
+                        }));
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"{BeatPulseKeys.BEATPULSE_DEFAULT_PATH}")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+            response.Content.Headers.ContentType.MediaType.Should().Be("application/json");
+
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Contain("\"Name\":\"self\"");
+            body.Should().Contain("\"Name\":\"nok\"");
+            body.Should().Contain("\"Name\":\"ok\"");
+        }
+
+        [Fact]
+        public async Task return_plain_text_result_when_EnableDetailedOutput_is_false()
+        {
+            var webHostBuilder = new WebHostBuilder()
+                .UseStartup<DefaultStartup>()
+                .UseBeatPulse()
+                .ConfigureServices(services =>
+                {
+                    services.AddBeatPulse(context =>
+                    {
+                        var httpClient = new HttpClient();
+
+                        context.Add(new ActionLiveness("nok", "nok", async (httpContext, token) =>
+                        {
+                            var responseMessage = await httpClient.GetAsync("http://notexist/api", token);
+
+                            return responseMessage.IsSuccessStatusCode
+                                ? ("OK", true)
+                                : ("the not exist api is broken!", false);
+                        }));
+
+                        context.Add(new ActionLiveness("ok", "ok", async (httpContext, token) =>
+                        {
+                            var responseMessage = await httpClient.GetAsync("http://www.google.es", token);
+
+                            return responseMessage.IsSuccessStatusCode
+                                ? ("OK", true)
+                                : ("the not exist api is broken!", false);
+                        }));
+                    });
+                });
+
+            var server = new TestServer(webHostBuilder);
+
+            var response = await server.CreateRequest($"{BeatPulseKeys.BEATPULSE_DEFAULT_PATH}")
+                .GetAsync();
+
+            response.StatusCode
+                .Should().Be(HttpStatusCode.ServiceUnavailable);
+            response.Content.Headers.ContentType.MediaType.Should().Be("text/plain");
+
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().Be("ServiceUnavailable");
+        }
+    }
+}


### PR DESCRIPTION
I have doubts about how to pass BeatPulseOptions to the BeatPulseService. In the current implementation is an extra parameter to the IsHealthy method. I think it is better option than injecting the options in the service. Forces all implementers to care about BeatPulseOptions. 