### PR TITLE
Solves issue #17

### DIFF
--- a/samples/HttpApi-Basic/Startup.cs
+++ b/samples/HttpApi-Basic/Startup.cs
@@ -6,9 +6,11 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace HttpApi_Basic
 {
+
     public class Startup
     {
         public Startup(IConfiguration configuration)
@@ -26,9 +28,11 @@ namespace HttpApi_Basic
                 //add sql server health check
                 setup.AddSqlServer("Server=.;Initial Catalog=master;Integrated Security=true");
 
-                //add custom health check
-                setup.Add(new ActionLiveness("cat", "catapi", (httpContext, cancellationToken) =>
+                //add custom health check using factory method. Using factory method allows us to get services through IServiceProvider
+                setup.Add("catapi", sp => new ActionLiveness("cat", "catapi", (httpContext, cancellationToken) =>
                 {
+                    var log = sp.GetRequiredService<ILogger<ActionLiveness>>();
+                    log.LogInformation("Running ActionLiveness");
                     if ((DateTime.UtcNow.Minute & 1) == 1)
                     {
                         return Task.FromResult(("OK", true));

--- a/src/BeatPulse/Core/BeatPulseContext.cs
+++ b/src/BeatPulse/Core/BeatPulseContext.cs
@@ -1,26 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BeatPulse.Core
 {
     public sealed class BeatPulseContext
     {
-        private readonly Dictionary<string, IBeatPulseLiveness> _activeLiveness = new Dictionary<string, IBeatPulseLiveness>();
+        private readonly Dictionary<string, IBeatPulseLivenessRegistration> _registeredLiveness = new Dictionary<string, IBeatPulseLivenessRegistration>();
 
-        public BeatPulseContext Add(IBeatPulseLiveness liveness)
+        private IServiceProvider _serviceProvider;
+
+        internal void UseServiceProvider(IServiceProvider sp) => _serviceProvider = sp;
+
+        public BeatPulseContext Add(IBeatPulseLivenessRegistration registration)
         {
-            if (liveness == null)
+            if (registration == null)
             {
-                throw new ArgumentNullException(nameof(liveness));
+                throw new ArgumentNullException(nameof(registration));
             }
 
-            var path = liveness.Path;
-
+            var path = registration.Path;
             if (!string.IsNullOrEmpty(path))
             {
-                if (!_activeLiveness.ContainsKey(path))
+                if (!_registeredLiveness.ContainsKey(path))
                 {
-                    _activeLiveness.Add(path, liveness);
+                    _registeredLiveness.Add(path, registration);
                 }
                 else
                 {
@@ -32,21 +36,23 @@ namespace BeatPulse.Core
             else
             {
                 throw new InvalidOperationException("The global path is automatically used for beat pulse.");
+
             }
         }
 
+
         internal IBeatPulseLiveness FindLiveness(string path)
         {
-            _activeLiveness.TryGetValue(path, out IBeatPulseLiveness check);
+            _registeredLiveness.TryGetValue(path, out IBeatPulseLivenessRegistration check);
 
-            return check;
+            return check?.GetOrCreateLiveness(_serviceProvider);
         }
 
         internal IEnumerable<IBeatPulseLiveness> AllLiveness
         {
             get
             {
-                return _activeLiveness.Values;
+                return _registeredLiveness.Values.Select(r => r.GetOrCreateLiveness(_serviceProvider));
             }
         }
     }

--- a/src/BeatPulse/Core/BeatPulseFactoryRegistration.cs
+++ b/src/BeatPulse/Core/BeatPulseFactoryRegistration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BeatPulse.Core
+{
+    public class BeatPulseFactoryRegistration : IBeatPulseLivenessRegistration
+    {
+        private readonly Func<IServiceProvider, IBeatPulseLiveness> _creator;
+
+        public string Path { get; }
+        public Guid Id { get; }
+
+        public BeatPulseFactoryRegistration(string path, Func<IServiceProvider, IBeatPulseLiveness> creator)
+        {
+            _creator = creator ?? throw new ArgumentNullException(nameof(creator));
+            Id = Guid.NewGuid();
+            Path = path;
+        }
+
+        public IBeatPulseLiveness GetOrCreateLiveness(IServiceProvider sp) => _creator.Invoke(sp);
+    }
+}

--- a/src/BeatPulse/Core/BeatPulseInstanceRegistration.cs
+++ b/src/BeatPulse/Core/BeatPulseInstanceRegistration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BeatPulse.Core
+{
+    public class BeatPulseInstanceRegistration : IBeatPulseLivenessRegistration
+    {
+
+        private readonly IBeatPulseLiveness _instance;
+
+        public string Path => _instance.Path;
+        public Guid Id { get; }
+
+        public BeatPulseInstanceRegistration(IBeatPulseLiveness liveness)
+        {
+            _instance = liveness ?? throw new ArgumentNullException(nameof(liveness));
+            Id = Guid.NewGuid();
+        }
+
+        public IBeatPulseLiveness GetOrCreateLiveness(IServiceProvider sp) => _instance;
+    }
+}

--- a/src/BeatPulse/Core/BeatPulseService.cs
+++ b/src/BeatPulse/Core/BeatPulseService.cs
@@ -16,11 +16,12 @@ namespace BeatPulse.Core
         private readonly ILogger<BeatPulseService> _logger;
         private readonly IHostingEnvironment _environment;
 
-        public BeatPulseService(BeatPulseContext context, IHostingEnvironment environment, ILogger<BeatPulseService> logger)
+        public BeatPulseService(BeatPulseContext context, IHostingEnvironment environment, ILogger<BeatPulseService> logger, IServiceProvider serviceProvider)
         {
             _beatPulseContext = context ?? throw new ArgumentNullException(nameof(context));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            context.UseServiceProvider(serviceProvider);
         }
 
         public async Task<IEnumerable<LivenessResult>> IsHealthy(string path, BeatPulseOptions options, HttpContext httpContext)

--- a/src/BeatPulse/Core/BulsePulseContextExtensions.cs
+++ b/src/BeatPulse/Core/BulsePulseContextExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BeatPulse.Core
+{
+    public static class BulsePulseContextExtensions
+    {
+        public static BeatPulseContext Add(this BeatPulseContext ctx, IBeatPulseLiveness liveness) 
+            => ctx.Add(new BeatPulseInstanceRegistration(liveness));
+        public static BeatPulseContext Add(this BeatPulseContext ctx, string path, Func<IServiceProvider, IBeatPulseLiveness> creator)
+            => ctx.Add(new BeatPulseFactoryRegistration(path, creator));
+    }
+}

--- a/src/BeatPulse/Core/IBeatPulseLivenessRegistration.cs
+++ b/src/BeatPulse/Core/IBeatPulseLivenessRegistration.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BeatPulse.Core
+{
+    public interface IBeatPulseLivenessRegistration
+    {
+        Guid Id { get; }
+        string Path { get; }
+        IBeatPulseLiveness GetOrCreateLiveness(IServiceProvider sp);
+    }
+
+}


### PR DESCRIPTION
Hi.
This PR solves issue #17 

Changes outlined:

- Now `BeatPulseContext` has a method Add that accepts a `IBeatPulseLivenessRegistration`
- There are two types of registrations (instance & factory)
- Previous functionality (adding liveness instance ) is provided through extension method
- Factory registrations create its liveness each time using a `Func<IServiceProvider, IBeatPulseLiveness>`
- `BeatPulseContext` gets a valid `IServiceProvider` through internal method called by `BeatPulseService` when created
