### PR TITLE
Remove unnecessary Any()

### DIFF
--- a/src/BeatPulse/Core/BeatPulseService.cs
+++ b/src/BeatPulse/Core/BeatPulseService.cs
@@ -73,9 +73,8 @@ namespace BeatPulse.Core
 
             var trackerTasks = new List<Task>();
 
-            if (_beatPulseContext.AllTrackers != null
-                && _beatPulseContext.AllTrackers.Any())
-            { 
+            if (_beatPulseContext.AllTrackers != null)
+            {
                 foreach (var tracker in _beatPulseContext.AllTrackers)
                 {
                     _logger.LogInformation($"Sending liveness result to track {tracker.Name}.");


### PR DESCRIPTION
Hi guys,

I think the Any() iteration throught the trackers could be removed and only check if AllTrackers is not null is enough because we could save one loop for list because next is a foreach.

Regards!