### PR TITLE
Fix notifications not running when a period is set

### DIFF
--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -209,7 +209,7 @@ namespace BeatPulse.UI.Core
 
             if (lastNotification != null
                 &&
-                (DateTime.UtcNow - lastNotification.LastNotified).Seconds < _settings.MinimumSecondsBetweenFailureNotifications)
+                (DateTime.UtcNow - lastNotification.LastNotified).TotalSeconds < _settings.MinimumSecondsBetweenFailureNotifications)
             {
                 _logger.LogInformation("Notification is not performed becaused is already notified and the elapsed time is less than configured.");
             }


### PR DESCRIPTION
Changed TimeSpan.Seconds to TimeSpan.TotalSeconds since the seconds property returns the seconds part of the timestamp and not the whole timestamp expressed in seconds.