### PR TITLE
AddUrlGroup works with UriLivenessOptions

### DIFF
--- a/samples/BeatPulseLiveness/Startup.cs
+++ b/samples/BeatPulseLiveness/Startup.cs
@@ -35,6 +35,14 @@ namespace BeatPulseLiveness
             {
                 setup.AddUrlGroup(new Uri[] { new Uri("http://www.google.es"), new Uri("http://nonexisting.com") });
 
+                setup.AddUrlGroup(opt =>
+                {
+                    opt.AddUri(new Uri("http://google.com"), uri =>
+                    {
+                        uri.AddCustomHeader("X-Method-Override", "DELETE");
+                    });
+                }, "uri-group2", "UriLiveness2");
+
                 //
                 //add existing liveness packages
                 //

--- a/src/BeatPulse.Uris/BeatPulseContextExtensions.cs
+++ b/src/BeatPulse.Uris/BeatPulseContextExtensions.cs
@@ -13,7 +13,10 @@ namespace BeatPulse
             return context.AddLiveness(name, setup =>
             {
                 setup.UsePath(defaultPath);
-                setup.UseLiveness(new UriLiveness(new System.Uri[] { uri }, HttpMethod.Get));
+
+                var options = new UriLivenessOptions();
+                options.AddUri(uri);
+                setup.UseLiveness(new UriLiveness(options));
             });
         }
 
@@ -22,7 +25,10 @@ namespace BeatPulse
             return context.AddLiveness(name, setup =>
             {
                 setup.UsePath(defaultPath);
-                setup.UseLiveness(new UriLiveness(new Uri[] { uri }, httpMethod));
+                var options = new UriLivenessOptions();
+                options.AddUri(uri);
+                options.UseHttpMethod(httpMethod);
+                setup.UseLiveness(new UriLiveness(options));
             });
         }
 
@@ -31,7 +37,13 @@ namespace BeatPulse
             return context.AddLiveness(name, setup =>
             {
                 setup.UsePath(defaultPath);
-                setup.UseLiveness(new UriLiveness(uris, HttpMethod.Get));
+                var options = new UriLivenessOptions();
+                foreach (var uri in uris)
+                {
+                    options.AddUri(uri);
+                }
+
+                setup.UseLiveness(new UriLiveness(options));
             });
         }
 
@@ -40,8 +52,29 @@ namespace BeatPulse
             return context.AddLiveness(name, setup =>
             {
                 setup.UsePath(defaultPath);
-                setup.UseLiveness(new UriLiveness(uris, httpMethod));
+
+                var options = new UriLivenessOptions();
+                options.UseHttpMethod(httpMethod);
+                foreach (var uri in uris)
+                {
+                    options.AddUri(uri);
+                }
+
+                setup.UseLiveness(new UriLiveness(options));
             });
         }
+
+        public static BeatPulseContext AddUrlGroup(this BeatPulseContext context, Action<UriLivenessOptions> uriOptions, string defaultPath = "uri-group", string name = nameof(UriLiveness))
+        {
+            return context.AddLiveness(name, setup =>
+            {
+                setup.UsePath(defaultPath);
+                var options = new UriLivenessOptions();
+                uriOptions.Invoke(options);
+                setup.UseLiveness(new UriLiveness(options));
+            });
+
+        }
+
     }
 }

--- a/src/BeatPulse.Uris/UriLiveness.cs
+++ b/src/BeatPulse.Uris/UriLiveness.cs
@@ -11,19 +11,23 @@ namespace BeatPulse.Uris
     public class UriLiveness
         : IBeatPulseLiveness
     {
-        private readonly IEnumerable<Uri> _uris;
-        private readonly HttpMethod _httpMethod;
+        private readonly UriLivenessOptions _options;
 
-        public UriLiveness(IEnumerable<Uri> uris, HttpMethod httpMethod)
-        {
-            _uris = uris;
-            _httpMethod = httpMethod;
-        }
+
+        public UriLiveness(UriLivenessOptions options) => _options = options;
 
         public async Task<(string, bool)> IsHealthy(HttpContext context, LivenessExecutionContext livenessContext, CancellationToken cancellationToken = default)
         {
-            foreach (var item in _uris)
+            var defaultHttpMethod = _options.HttpMethod;
+            var defaultCodes = _options.ExpectedHttpCodes;
+            var idx = 0;
+
+            foreach (var item in _options.Uris)
             {
+                var method = item.HttpMethod ?? defaultHttpMethod;
+                var expectedCodes = item.ExpectedHttpCodes ?? defaultCodes;
+                var uri = item.Uri;
+
                 if (cancellationToken.IsCancellationRequested)
                 {
                     return (BeatPulseKeys.BEATPULSE_HEALTHCHECK_DEFAULT_ERROR_MESSAGE, false);
@@ -33,17 +37,23 @@ namespace BeatPulse.Uris
                 {
                     using (var httpClient = new HttpClient())
                     {
-                        var requestMessage = new HttpRequestMessage(_httpMethod, item);
+                        var requestMessage = new HttpRequestMessage(method, uri);
+
+                        foreach (var header in item.Headers)
+                        {
+                            requestMessage.Headers.Add(header.Name, header.Value);
+                        }
 
                         var response = await httpClient.SendAsync(requestMessage);
 
-                        if (!response.IsSuccessStatusCode)
+                        if (!((int)response.StatusCode >= expectedCodes.Min && (int)response.StatusCode <= expectedCodes.Max))
                         {
                             var message = !livenessContext.IsDevelopment ? string.Format(BeatPulseKeys.BEATPULSE_HEALTHCHECK_DEFAULT_ERROR_MESSAGE, livenessContext.Name)
-                                : $"Discover endpoint is not responding with SuccessStatusCode, the current status is {response.StatusCode}.";
+                                : $"Discover endpoint #{idx} is not responding with code in {expectedCodes.Min}...{expectedCodes.Max} range, the current status is {response.StatusCode}.";
 
                             return (message, false);
                         }
+                        idx++;
                     }
                 }
                 catch (Exception ex)

--- a/src/BeatPulse.Uris/UriLivenessOptions.cs
+++ b/src/BeatPulse.Uris/UriLivenessOptions.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace BeatPulse.Uris
+{
+
+    public interface IUriOptions
+    {
+        IUriOptions UseGet();
+        IUriOptions UsePost();
+        IUriOptions UseHttpMethod(HttpMethod methodToUse);
+        IUriOptions ExpectHttpCode(int codeToExpect);
+        IUriOptions ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect);
+        IUriOptions AddCustomHeader(string name, string value);
+    }
+
+    public class UriOptions : IUriOptions
+    {
+        public HttpMethod HttpMethod { get; private set; }
+        public (int Min, int Max)? ExpectedHttpCodes { get; private set; }
+        public Uri Uri { get; }
+
+        private readonly List<(string Name, string Value)> _headers;
+
+        internal IEnumerable<(string Name, string Value)> Headers => _headers;
+
+        public UriOptions(Uri uri)
+        {
+            Uri = uri;
+            ExpectedHttpCodes = null;
+            HttpMethod = null;
+            _headers = new List<(string Name, string Value)>();
+        }
+
+        public IUriOptions AddCustomHeader(string name, string value)
+        {
+            _headers.Add((name, value));
+            return this;
+        }
+
+
+        IUriOptions IUriOptions.UseGet()
+        {
+            HttpMethod = HttpMethod.Get;
+            return this;
+        }
+        IUriOptions IUriOptions.UsePost()
+        {
+            HttpMethod = HttpMethod.Post;
+            return this;
+        }
+
+        IUriOptions IUriOptions.ExpectHttpCode(int codeToExpect)
+        {
+            ExpectedHttpCodes = (codeToExpect, codeToExpect);
+            return this;
+        }
+
+        IUriOptions IUriOptions.ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect)
+        {
+            ExpectedHttpCodes = (minCodeToExpect, maxCodeToExpect);
+            return this;
+        }
+        IUriOptions IUriOptions.UseHttpMethod(HttpMethod methodToUse)
+        {
+            HttpMethod = methodToUse;
+            return this;
+        }
+    }
+
+    public class UriLivenessOptions
+    {
+        private readonly List<UriOptions> _uris;
+        internal HttpMethod HttpMethod { get; private set; }
+        internal IEnumerable<UriOptions> Uris => _uris;
+
+        internal (int Min, int Max) ExpectedHttpCodes { get; private set; }
+
+        public UriLivenessOptions()
+        {
+            _uris = new List<UriOptions>();
+            ExpectedHttpCodes = (200, 299);              // HTTP Succesful status codes
+            HttpMethod = HttpMethod.Get;
+        }
+
+        public UriLivenessOptions UseGet()
+        {
+            HttpMethod = HttpMethod.Get;
+            return this;
+        }
+
+        public UriLivenessOptions UsePost()
+        {
+            HttpMethod = HttpMethod.Post;
+            return this;
+        }
+
+        public UriLivenessOptions UseHttpMethod(HttpMethod methodToUse)
+        {
+            HttpMethod = methodToUse;
+            return this;
+        }
+
+        public UriLivenessOptions AddUri(Uri uriToAdd, Action<IUriOptions> uriOptions = null)
+        {
+            var uri = new UriOptions(uriToAdd);
+            uriOptions?.Invoke(uri);
+            _uris.Add(uri);
+            return this;
+        }
+
+        public UriLivenessOptions ExpectHttpCode(int codeToExpect)
+        {
+            ExpectedHttpCodes = (codeToExpect, codeToExpect);
+            return this;
+        }
+        public UriLivenessOptions ExpectHttpCodes(int minCodeToExpect, int maxCodeToExpect)
+        {
+            ExpectedHttpCodes = (minCodeToExpect, maxCodeToExpect);
+            return this;
+        }
+
+
+    }
+}


### PR DESCRIPTION
This should solve issue #67 

New usage is like:

```cs
setup.AddUrlGroup(opt =>
{
    opt.AddUri(new Uri("http://google.com"), uri =>
    {
        uri.AddCustomHeader("X-Method-Override", "DELETE");
    });
}, "uri-group2", "UriLiveness2");
```

All previous `AddUrlGroup` methods overload work as previously did.

@unaizorrilla Please, review and merge if appropiate. Thx