### PR TITLE
HttpClient - related memory leak fixture

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -56,7 +56,7 @@
     <BeatpulseRedisPackageVersion>3.0.1</BeatpulseRedisPackageVersion>
     <BeatPulseSqlitePackageVersion>3.0.0</BeatPulseSqlitePackageVersion>
     <BeatPulseSqlServerPackageVersion>3.0.0</BeatPulseSqlServerPackageVersion>
-    <BeatPulseUIPackageVersion>3.0.4</BeatPulseUIPackageVersion>
+    <BeatPulseUIPackageVersion>3.0.5</BeatPulseUIPackageVersion>
     <BeatPulseKafkaVersion>3.0.0</BeatPulseKafkaVersion>
     <BeatPulseEventStoreVersion>3.0.0</BeatPulseEventStoreVersion>
     <BeatPulseRabbitMQPackageVersion>3.0.0</BeatPulseRabbitMQPackageVersion>

--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -24,6 +24,10 @@ namespace BeatPulse.UI.Core
         private readonly BeatPulseSettings _settings;
         private readonly ILogger<LivenessRunner> _logger;
         
+        static LivenessRunner() {
+            _httpClient = new HttpClient();
+        }
+
         public LivenessRunner(LivenessDb context,
             ILivenessFailureNotifier failureNotifier,
             IOptions<BeatPulseSettings> settings,
@@ -33,7 +37,6 @@ namespace BeatPulse.UI.Core
             _failureNotifier = failureNotifier ?? throw new ArgumentNullException(nameof(failureNotifier));
             _settings = settings.Value ?? throw new ArgumentNullException(nameof(settings));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _httpClient = new HttpClient();
         }
 
         public async Task Run(CancellationToken cancellationToken)


### PR DESCRIPTION
HttpClient is created everytime LivenessRunner is what causes leak of objects that .Net Core stores internally. It should be created once in static constructor.