### PR TITLE
Multiple disposals of DBContext causes memory leaks

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -56,7 +56,7 @@
     <BeatpulseRedisPackageVersion>3.0.1</BeatpulseRedisPackageVersion>
     <BeatPulseSqlitePackageVersion>3.0.0</BeatPulseSqlitePackageVersion>
     <BeatPulseSqlServerPackageVersion>3.0.0</BeatPulseSqlServerPackageVersion>
-    <BeatPulseUIPackageVersion>3.0.3</BeatPulseUIPackageVersion>
+    <BeatPulseUIPackageVersion>3.0.4</BeatPulseUIPackageVersion>
     <BeatPulseKafkaVersion>3.0.0</BeatPulseKafkaVersion>
     <BeatPulseEventStoreVersion>3.0.0</BeatPulseEventStoreVersion>
     <BeatPulseRabbitMQPackageVersion>3.0.0</BeatPulseRabbitMQPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -56,7 +56,7 @@
     <BeatpulseRedisPackageVersion>3.0.1</BeatpulseRedisPackageVersion>
     <BeatPulseSqlitePackageVersion>3.0.0</BeatPulseSqlitePackageVersion>
     <BeatPulseSqlServerPackageVersion>3.0.0</BeatPulseSqlServerPackageVersion>
-    <BeatPulseUIPackageVersion>3.0.4</BeatPulseUIPackageVersion>
+    <BeatPulseUIPackageVersion>3.0.5</BeatPulseUIPackageVersion>
     <BeatPulseKafkaVersion>3.0.0</BeatPulseKafkaVersion>
     <BeatPulseEventStoreVersion>3.0.0</BeatPulseEventStoreVersion>
     <BeatPulseRabbitMQPackageVersion>3.0.0</BeatPulseRabbitMQPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -25,11 +25,11 @@
     <MySqlConnectorVersion>0.40.4</MySqlConnectorVersion>
     <MicrosoftAzureDocumentDbCoreVersion>1.9.1</MicrosoftAzureDocumentDbCoreVersion>
     <MicrosoftDataSqliteVersion>2.0.1</MicrosoftDataSqliteVersion>
-    <NewtonSoftJsonVersion>11.0.2</NewtonSoftJsonVersion>
-    <MicrosoftEntityFrameworkCoreVersion>2.1.0</MicrosoftEntityFrameworkCoreVersion>
-    <MicrosoftEntityFrameworkCoreDesignVersion>2.1.0</MicrosoftEntityFrameworkCoreDesignVersion>
-    <MicrosoftEntityFrameworkCoreSqlLiteVersion>2.1.0</MicrosoftEntityFrameworkCoreSqlLiteVersion>
-    <MicrosoftEntityFrameworkCoreSqlLiteDesignVersion>1.1.5</MicrosoftEntityFrameworkCoreSqlLiteDesignVersion>
+    <NewtonSoftJsonVersion>12.0.1</NewtonSoftJsonVersion>
+    <MicrosoftEntityFrameworkCoreVersion>2.1.4</MicrosoftEntityFrameworkCoreVersion>
+    <MicrosoftEntityFrameworkCoreDesignVersion>2.1.4</MicrosoftEntityFrameworkCoreDesignVersion>
+    <MicrosoftEntityFrameworkCoreSqlLiteVersion>2.1.4</MicrosoftEntityFrameworkCoreSqlLiteVersion>
+    <MicrosoftEntityFrameworkCoreSqlLiteDesignVersion>1.1.6</MicrosoftEntityFrameworkCoreSqlLiteDesignVersion>
     <MicrosoftExtensionConfigurationBinderVersion>2.1.1</MicrosoftExtensionConfigurationBinderVersion>
     <ConfluentKafkaVersion>0.11.4</ConfluentKafkaVersion>
     <MicrosoftAzureEventHubsVersion>2.0.0</MicrosoftAzureEventHubsVersion>

--- a/src/BeatPulse.UI/Core/HostedService/LivenessHostedService.cs
+++ b/src/BeatPulse.UI/Core/HostedService/LivenessHostedService.cs
@@ -49,8 +49,8 @@ namespace BeatPulse.UI.Core.HostedService
                 _logger.LogDebug("Executing LivenessHostedService.");
 
                 using (var scope = _serviceScopeFactory.CreateScope())
-                using (var runner = scope.ServiceProvider.GetRequiredService<ILivenessRunner>())
                 {
+                    var runner = scope.ServiceProvider.GetRequiredService<ILivenessRunner>();
                     try
                     {
                         await runner.Run(cancellationToken);

--- a/src/BeatPulse.UI/Core/HostedService/LivenessHostedService.cs
+++ b/src/BeatPulse.UI/Core/HostedService/LivenessHostedService.cs
@@ -63,7 +63,7 @@ namespace BeatPulse.UI.Core.HostedService
                     }
                 }
 
-                await Task.Delay(_settings.EvaluationTimeOnSeconds * 1000);
+                await Task.Delay(_settings.EvaluationTimeOnSeconds * 1000, cancellationToken);
             }
         }
     }

--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -45,7 +45,7 @@ namespace BeatPulse.UI.Core
             {
                 var liveness = await _context.LivenessConfigurations
                     .AsNoTracking()
-                   .ToListAsync();
+                   .ToListAsync(cancellationToken);
 
                 foreach (var item in liveness)
                 {
@@ -237,15 +237,6 @@ namespace BeatPulse.UI.Core
 
         public void Dispose()
         {
-            if (_context != null)
-            {
-                _context.Dispose();
-            }
-
-            if (_failureNotifier != null)
-            {
-                _failureNotifier.Dispose();
-            }
         }
 
         private class OutputLivenessMessageResponse

--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -24,6 +24,10 @@ namespace BeatPulse.UI.Core
         private readonly BeatPulseSettings _settings;
         private readonly ILogger<LivenessRunner> _logger;
         
+        static LivenessRunner() {
+            _httpClient = new HttpClient();
+        }
+
         public LivenessRunner(LivenessDb context,
             ILivenessFailureNotifier failureNotifier,
             IOptions<BeatPulseSettings> settings,
@@ -33,7 +37,6 @@ namespace BeatPulse.UI.Core
             _failureNotifier = failureNotifier ?? throw new ArgumentNullException(nameof(failureNotifier));
             _settings = settings.Value ?? throw new ArgumentNullException(nameof(settings));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _httpClient = new HttpClient();
         }
 
         public async Task Run(CancellationToken cancellationToken)

--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -56,9 +56,9 @@ namespace BeatPulse.UI.Core
                         break;
                     }
 
-                    var (response, isHealthy) = await EvaluateLiveness(item);
+                    var (response, isHealthy) = await EvaluateLiveness(item, cancellationToken);
 
-                    if (isHealthy && (await HasLivenessRecoveredFromFailure(item)))
+                    if (isHealthy && (await HasLivenessRecoveredFromFailure(item, cancellationToken)))
                     {
                         await _failureNotifier.NotifyWakeUp(item.LivenessName);
                     }
@@ -67,25 +67,27 @@ namespace BeatPulse.UI.Core
                         await _failureNotifier.NotifyDown(item.LivenessName, GetFailedMessageFromContent(response));
                     }
 
-                    await SaveExecutionHistory(item, response, isHealthy);
+                    await SaveExecutionHistory(item, response, isHealthy, cancellationToken);
                 }
 
                 _logger.LogDebug("LivenessRuner run is completed.");
             }
         }
 
-        protected internal virtual Task<HttpResponseMessage> PerformRequest(string uri)
+        protected internal virtual Task<HttpResponseMessage> PerformRequest(string uri, CancellationToken cancellationToken)
         {
-            return _httpClient.GetAsync(uri);
+            return _httpClient.GetAsync(uri, cancellationToken);
         }
 
-        private async Task<(string response, bool ishealthy)> EvaluateLiveness(LivenessConfiguration livenessConfiguration)
+        private async Task<(string response, bool ishealthy)> EvaluateLiveness(
+            LivenessConfiguration livenessConfiguration,
+            CancellationToken cancellationToken)
         {
             var (uri, name) = livenessConfiguration;
 
             try
             {
-                using (var response = await PerformRequest(uri))
+                using (var response = await PerformRequest(uri, cancellationToken))
                 {
                     var success = response.IsSuccessStatusCode;
 
@@ -103,17 +105,17 @@ namespace BeatPulse.UI.Core
             }
         }
 
-        private async Task<LivenessExecution> GetLivenessExecution(LivenessConfiguration liveness)
+        private async Task<LivenessExecution> GetLivenessExecution(LivenessConfiguration liveness, CancellationToken cancellationToken)
         {
             return await _context.LivenessExecutions
                 .Include(le => le.History)
                 .Where(le => le.LivenessName.Equals(liveness.LivenessName, StringComparison.InvariantCultureIgnoreCase))
-                .SingleOrDefaultAsync();
+                .SingleOrDefaultAsync(cancellationToken);
         }
 
-        private async Task<bool> HasLivenessRecoveredFromFailure(LivenessConfiguration liveness)
+        private async Task<bool> HasLivenessRecoveredFromFailure(LivenessConfiguration liveness, CancellationToken cancellationToken)
         {
-            var previousLivenessExecution = await GetLivenessExecution(liveness);
+            var previousLivenessExecution = await GetLivenessExecution(liveness, cancellationToken);
             if (previousLivenessExecution != null)
             {
                 var previousStatus = (LivenessStatus)Enum.Parse(typeof(LivenessStatus), previousLivenessExecution.Status);
@@ -123,11 +125,11 @@ namespace BeatPulse.UI.Core
             return false;
         }
 
-        private async Task SaveExecutionHistory(LivenessConfiguration liveness, string content, bool isHealthy)
+        private async Task SaveExecutionHistory(LivenessConfiguration liveness, string content, bool isHealthy, CancellationToken cancellationToken)
         {
             _logger.LogDebug("LivenessRuner save a new liveness execution history.");
 
-            var livenessExecution = await GetLivenessExecution(liveness);
+            var livenessExecution = await GetLivenessExecution(liveness, cancellationToken);
 
             var currentStatus = GetDetailedStatusFromContent(isHealthy, content);
             var currentStatusName = Enum.GetName(typeof(LivenessStatus), currentStatus);
@@ -176,10 +178,10 @@ namespace BeatPulse.UI.Core
                 };
 
                 await _context.LivenessExecutions
-                    .AddAsync(livenessExecution);
+                    .AddAsync(livenessExecution, cancellationToken);
             }
 
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync(cancellationToken);
         }
 
         private LivenessStatus GetDetailedStatusFromContent(bool isHealthy, string content)

--- a/src/BeatPulse.UI/Core/LivenessRunner.cs
+++ b/src/BeatPulse.UI/Core/LivenessRunner.cs
@@ -47,9 +47,9 @@ namespace BeatPulse.UI.Core
                     .AsNoTracking()
                     .ToListAsync(cancellationToken);
 
-                var evaulatedLiveness = await Task.WhenAll(liveness.ConvertAll(o => EvaluateLiveness(o, cancellationToken)));
+                var evaluatedLiveness = await Task.WhenAll(liveness.ConvertAll(o => EvaluateLiveness(o, cancellationToken)));
 
-                foreach (var (response, isHealthy, item) in evaulatedLiveness)
+                foreach (var (response, isHealthy, item) in evaluatedLiveness)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {

--- a/src/BeatPulse.UI/Core/Notifications/ILivenessFailureNotifier.cs
+++ b/src/BeatPulse.UI/Core/Notifications/ILivenessFailureNotifier.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace BeatPulse.UI.Core.Notifications
 {
-    interface ILivenessFailureNotifier : IDisposable
+    interface ILivenessFailureNotifier
     {
         Task NotifyDown(string livenessName, string message);
 

--- a/src/BeatPulse.UI/Core/Notifications/WebHookFailureNotifier.cs
+++ b/src/BeatPulse.UI/Core/Notifications/WebHookFailureNotifier.cs
@@ -114,13 +114,5 @@ namespace BeatPulse.UI.Core.Notifications
                 _logger.LogError($"The failure notification for {name} has not executed successfully.", exception);
             }
         }
-
-        public void Dispose()
-        {
-            if (_db != null)
-            {
-                _db.Dispose();
-            }
-        }
     }
 }

--- a/src/BeatPulse.UI/Middleware/UIApiEndpointMiddleware.cs
+++ b/src/BeatPulse.UI/Middleware/UIApiEndpointMiddleware.cs
@@ -24,8 +24,8 @@ namespace BeatPulse.UI.Middleware
         public async Task InvokeAsync(HttpContext context, IServiceScopeFactory serviceScopeFactory)
         {
             using (var scope = serviceScopeFactory.CreateScope())
-            using (var db = scope.ServiceProvider.GetService<LivenessDb>())
             {
+                var db = scope.ServiceProvider.GetService<LivenessDb>();
 
                 var cancellationToken = new CancellationToken();
 

--- a/tests/UnitTests/BeatPulse.UI/Core/Builders/FakeLivenessRunner.cs
+++ b/tests/UnitTests/BeatPulse.UI/Core/Builders/FakeLivenessRunner.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BeatPulse.UI.Core.Builders
@@ -26,11 +27,11 @@ namespace BeatPulse.UI.Core.Builders
             _content = content;
         }
 
-        protected internal override Task<HttpResponseMessage> PerformRequest(string uri)
+        protected internal override Task<HttpResponseMessage> PerformRequest(string uri, CancellationToken cancellationToken)
         {
-            var message  =  new HttpResponseMessage(_status)
+            var message = new HttpResponseMessage(_status)
             {
-                Content = new StringContent(_content,Encoding.UTF8,"application/json")
+                Content = new StringContent(_content, Encoding.UTF8, "application/json")
             };
 
             return Task.FromResult(message);


### PR DESCRIPTION
Datacontext was disposed couple of times.

1. it was disposed by every dependency that uses it - it shouldn't be because it is injected into them not created by them.
2. it was disposed directly by MiddleWare by using statement
3. it was disposed by scope disposal

In some cases DbContext was disposed before liveness runner was, then runner used it and usage was passed to sqlite driver below. driver itself resurects resources it used in this case. Because dbContext was already disposed it didn't redispose driver, so resources allocated by it left in memory.
I have also added usage of cancellationToken and upgraded dependencies. 
